### PR TITLE
Add whitelist for ReStock

### DIFF
--- a/GameData/Ablative-Airbrake/Ablative-Airbrake.restockwhitelist
+++ b/GameData/Ablative-Airbrake/Ablative-Airbrake.restockwhitelist
@@ -1,0 +1,1 @@
+Squad/Parts/Aero/HeatShield/


### PR DESCRIPTION
If not, the part got no texture when ReStock is installed.